### PR TITLE
Added options to power off with a delay and to shutdown server

### DIFF
--- a/octoprint_psucontrol_tapo/tapo.py
+++ b/octoprint_psucontrol_tapo/tapo.py
@@ -306,6 +306,16 @@ class Switchable(Device):
     def turn_off(self):
         return self.set_status(False)
 
+    def turn_off_delayed(self, delay):
+        return self.request("add_countdown_rule", {
+				"delay": int(delay),
+				"desired_states": {
+					"on": False
+				},
+				"enable": True,
+				"remain": int(delay)
+			});
+
     def toggle(self):
         return self.set_status(not self.get_status())
 

--- a/octoprint_psucontrol_tapo/templates/psucontrol_tapo_settings.jinja2
+++ b/octoprint_psucontrol_tapo/templates/psucontrol_tapo_settings.jinja2
@@ -22,4 +22,15 @@
             <input type="password" class="input" data-bind="value: settings.plugins.psucontrol_tapo.password" placeholder="">
         </div>
     </div>
+    <div class="control-group">
+        <label class="control-label">Power off delay (seconds)</label>
+        <div class="controls">
+            <input type="number" class="input" data-bind="value: settings.plugins.psucontrol_tapo.power_off_delay">
+        </div>
+    </div>
+    <div class="control-group">
+        <div class="controls">
+            <label class="checkbox"><input data-bind="checked: settings.plugins.psucontrol_tapo.shutdown_on_power_off" type="checkbox"> Shutdown on power off</label>
+        </div>
+    </div>
 </form>


### PR DESCRIPTION
I have my Octoprint server running from the same Tapo plug that my printer (in fact it is a RPi running from an USB port added to the printer) that is why I needed the possibility of powering off the printer with a delay, so that the server can be shutdown safely in the interim. I use these options combined with the "Turn PSU OFF when idle" feature of PSU Control for safe and unattended power off. Relevant Tapo API options have been taken from @fishbigger's TapoP100 repository.